### PR TITLE
Bug: Fix typos in `forvocl.rb`

### DIFF
--- a/forvocl.rb
+++ b/forvocl.rb
@@ -8,7 +8,7 @@ require 'optparse'
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = "Usage: example.rb [options]"
+  opts.banner = "Usage: forvocl.rb [options]"
 
   opts.on("-m", "--mp3", "Use mp3 files instead of ogg (default)") { options[:mp3] = true }
   opts.on("-l", "--list", "List all pronunciations") { options[:list] = true }
@@ -18,7 +18,7 @@ OptionParser.new do |opts|
 
 end.parse!
 
-config_dir = Dir.home + "/.config/gdcl/"
+config_dir = Dir.home + "/.config/forvocl/"
 
 # read key from config file, otherwise quit
 if File.exist?(config_dir + "config.yml")


### PR DESCRIPTION
Hello, @dohliam !

Appreciate your great work! :rose: However, I think that it is a long way to get stable. I have a proposal for this program:
## Fix typos in `forvocl.rb`

Since the executables have been renamed, some strings should be updated
too. The word `example.rb` should be changed to `forvocl.rb` accordingly and so is `/.config/gdcl/`.

This fixes typos which are imported in https://github.com/dohliam/forvocl/commit/c05e2c530c266ad20edfc14c82b3908dcf9343b0

Do you agree with me? :sweat_smile: Hope for your reply!

Yours sincerely! :bow: 
